### PR TITLE
Add mode and exclude arguments to genie_diff

### DIFF
--- a/filter_plugins/genie.py
+++ b/filter_plugins/genie.py
@@ -31,15 +31,10 @@ class FilterModule(object):
         if not HAS_PYATS:
             raise AnsibleFilterError("pyATS not found. Run 'pip install pyats'")
 
-        device = Device("uut", os=os)
+        device = Device("new_device", os=os)
 
         device.custom.setdefault("abstraction", {})["order"] = ["os"]
         device.cli = AttrDict({"execute": None})
-
-        # import sys;
-        # sys.stdin = open('/dev/tty')
-        # import pdb;
-        # pdb.set_trace()
 
         try:
             get_parser(command, device)
@@ -69,7 +64,6 @@ class FilterModule(object):
         supported_mode = ['add', 'remove', 'modified', None]
         if mode not in supported_mode:
             raise AnsibleFilterError("Mode '%s' is not supported. Specify %s." % (mode, supported_mode) )
-<<<<<<< HEAD
 
         config1 = Config(output1)
         config1.tree()
@@ -79,28 +73,13 @@ class FilterModule(object):
         config2.tree()
         dict2 = config2.config
 
-=======
-
-        config1 = Config(output1)
-        config1.tree()
-        dict1 = config1.config
-
-        config2 = Config(output2)
-        config2.tree()
-        dict2 = config2.config
-
->>>>>>> upstream/master
         dd = Diff(dict1, dict2, mode=mode, exclude=exclude)
         dd.findDiff()
         diff = str(dd)
         diff_list = diff.split('\n')
-<<<<<<< HEAD
 
         return diff_list
-=======
->>>>>>> upstream/master
 
-        return diff_list
 
     def filters(self):
         return {

--- a/filter_plugins/genie.py
+++ b/filter_plugins/genie.py
@@ -8,6 +8,7 @@ try:
     from genie.conf.base import Device, Testbed
     from genie.libs.parser.utils import get_parser
     from genie.utils.diff import Diff
+    from genie.utils.config import Config
     HAS_GENIE = True
 except ImportError:
     HAS_GENIE = False
@@ -30,10 +31,15 @@ class FilterModule(object):
         if not HAS_PYATS:
             raise AnsibleFilterError("pyATS not found. Run 'pip install pyats'")
 
-        device = Device("new_device", os=os)
+        device = Device("uut", os=os)
 
         device.custom.setdefault("abstraction", {})["order"] = ["os"]
         device.cli = AttrDict({"execute": None})
+
+        # import sys;
+        # sys.stdin = open('/dev/tty')
+        # import pdb;
+        # pdb.set_trace()
 
         try:
             get_parser(command, device)
@@ -50,7 +56,7 @@ class FilterModule(object):
         else:
             return None
 
-    def genie_diff(self, output1, output2):
+    def genie_diff(self, output1, output2, mode=None, exclude=None):
         if not PY3:
             raise AnsibleFilterError("Genie requires Python 3")
 
@@ -60,12 +66,41 @@ class FilterModule(object):
         if not HAS_PYATS:
             raise AnsibleFilterError("pyATS not found. Run 'pip install pyats'")
 
-        diff = Diff(output1, output2)
+        supported_mode = ['add', 'remove', 'modified', None]
+        if mode not in supported_mode:
+            raise AnsibleFilterError("Mode '%s' is not supported. Specify %s." % (mode, supported_mode) )
+<<<<<<< HEAD
 
-        diff.findDiff()
+        config1 = Config(output1)
+        config1.tree()
+        dict1 = config1.config
 
-        return diff
+        config2 = Config(output2)
+        config2.tree()
+        dict2 = config2.config
 
+=======
+
+        config1 = Config(output1)
+        config1.tree()
+        dict1 = config1.config
+
+        config2 = Config(output2)
+        config2.tree()
+        dict2 = config2.config
+
+>>>>>>> upstream/master
+        dd = Diff(dict1, dict2, mode=mode, exclude=exclude)
+        dd.findDiff()
+        diff = str(dd)
+        diff_list = diff.split('\n')
+<<<<<<< HEAD
+
+        return diff_list
+=======
+>>>>>>> upstream/master
+
+        return diff_list
 
     def filters(self):
         return {


### PR DESCRIPTION
- Add `mode` argument to display only added, removed, or modified commands.
- Add `exclude` argument to specify the command lists which is excluded when comparing before and after configs.
- Output result is displayed as a list.