### PR TITLE
Add genie_parser_diff filter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,14 +98,14 @@ Ansible role.  It contains modules, filters, and tasks:
         parsed_output: "{{ cli_output.stdout | pyats_parser('show ip route', 'iosxe') }}"
 ```
 
-### Using the `genie_diff` filter directly
+### Using the `pyats_diff` filter directly
 ```yaml
 - name: Diff current and snapshot
   set_fact:
     diff_output: "{{ current_output | pyats_diff(previous_output) }}"
 ```
 
-### Change ACL configuration and compare before and after configs using `genie_diff`
+### Change ACL configuration and compare before and after configs using `genie_config_diff`
 ```yaml
 ---
 
@@ -137,7 +137,7 @@ Ansible role.  It contains modules, filters, and tasks:
 
     - name: debug
       debug:
-        msg: "{{ result_before.stdout[0] | genie_diff(result_after.stdout[0], mode='add', exclude=exclude_list) }}"
+        msg: "{{ result_before.stdout[0] | genie_config_diff(result_after.stdout[0], mode='add', exclude=exclude_list) }}"
 
   vars:
     exclude_list:
@@ -152,9 +152,9 @@ In the playbook example above, variable `excluded_list`, which is defined as the
 
 #### Other examples
 ```yaml
-        msg: "{{ result_before.stdout[0] | genie_diff(result_after.stdout[0]) }}"
-        msg: "{{ result_before.stdout[0] | genie_diff(result_after.stdout[0], mode='remove') }}"
-        msg: "{{ result_before.stdout[0] | genie_diff(result_after.stdout[0], exclude=exclude_list) }}"
+        msg: "{{ result_before.stdout[0] | genie_config_diff(result_after.stdout[0]) }}"
+        msg: "{{ result_before.stdout[0] | genie_config_diff(result_after.stdout[0], mode='remove') }}"
+        msg: "{{ result_before.stdout[0] | genie_config_diff(result_after.stdout[0], exclude=exclude_list) }}"
 ```
 
 #### The result of example playbook
@@ -182,6 +182,23 @@ ok: [test3] => {
 
 PLAY RECAP ************************************************************************************
 test3                      : ok=4    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
+```
+
+
+### Compare show commands using `genie_parser_diff`
+This filter can compare the output of show commands parsed by Genie parser. The arguments `mode` and `exclude` also can be used.
+
+```yaml
+    - name: debug
+      debug:
+        msg: "{{ sh_int_parsed_before | genie_parser_diff(sh_int_parsed_after, mode='modified', exclude=exclude_list) }}"
+        
+  vars:
+    exclude_list:
+      - (.*in_octets.*)
+      - (.*in_pkts.*)
+      - (.*out_octets.*)
+      - (.*out_pkts.*)
 ```
 
 License

--- a/filter_plugins/genie.py
+++ b/filter_plugins/genie.py
@@ -51,7 +51,7 @@ class FilterModule(object):
         else:
             return None
 
-    def genie_diff(self, output1, output2, mode=None, exclude=None):
+    def genie_config_diff(self, output1, output2, mode=None, exclude=None):
         if not PY3:
             raise AnsibleFilterError("Genie requires Python 3")
 
@@ -81,8 +81,31 @@ class FilterModule(object):
         return diff_list
 
 
+    def genie_parser_diff(self, output1, output2, mode=None, exclude=None):
+        if not PY3:
+            raise AnsibleFilterError("Genie requires Python 3")
+
+        if not HAS_GENIE:
+            raise AnsibleFilterError("Genie not found. Run 'pip install genie'")
+
+        if not HAS_PYATS:
+            raise AnsibleFilterError("pyATS not found. Run 'pip install pyats'")
+
+        supported_mode = ['add', 'remove', 'modified', None]
+        if mode not in supported_mode:
+            raise AnsibleFilterError("Mode '%s' is not supported. Specify %s." % (mode, supported_mode) )
+
+        dd = Diff(output1, output2, mode=mode, exclude=exclude)
+        dd.findDiff()
+        diff = str(dd)
+        diff_list = diff.split('\n')
+
+        return diff_list
+
+
     def filters(self):
         return {
             'genie_parser': self.genie_parser,
-            'genie_diff': self.genie_diff
+            'genie_config_diff': self.genie_config_diff
+            'genie_parser_diff': self.genie_parser_diff
         }


### PR DESCRIPTION
I formerly modified `genie_diff` filter plugin. It can compare the raw outputs of "show running-config" or "show startup-config" but doesn't support the parsed outputs of "show interfaces" or "show cdp neighbors", etc.   
`genie_parser_diff` filter plugin supports the latter one.