### PR TITLE
Update Python path

### DIFF
--- a/library/pyats_parse_command.py
+++ b/library/pyats_parse_command.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/library/pyats_parse_config.py
+++ b/library/pyats_parse_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type


### PR DESCRIPTION
I've found that under certain circumstances (particularly when running in a venv), the static `/usr/bin/python` path causes these modules to break.  Setting to `/usr/bin/env python` has (in my testing, anyway) proven to work in a venv or not.